### PR TITLE
Fix message-id

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Swift-SMTP bird](https://github.com/IBM-Swift/Swift-SMTP/blob/master/Assets/swift-smtp-bird.png)
 
-Swift package for sending emails to an SMTP server.
+Swift package for sending emails through an SMTP server.
 
 [![Build Status](https://travis-ci.com/IBM-Swift/Swift-SMTP.svg?token=prrUzhsjZyXD9LxyWxge&branch=master)](https://travis-ci.com/IBM-Swift/Swift-SMTP.svg?token=prrUzhsjZyXD9LxyWxge&branch=master)
 ![macOS](https://img.shields.io/badge/os-macOS-green.svg?style=flat)
@@ -11,7 +11,7 @@ Swift package for sending emails to an SMTP server.
 
 ## Features
 
-- Connect securely through SSL/TLS if available
+- Connect securely through SSL/TLS when available
 - Authenticate with CRAM-MD5, LOGIN, PLAIN, or XOAUTH2
 - Send emails with local file, HTML, and raw data attachments
 - Add custom headers
@@ -49,10 +49,10 @@ Create a `Mail` object and use your `smtp` handle to send it. To set the sender 
 let drLight = User(name: "Dr. Light", email: "drlight@gmail.com")
 let megaman = User(name: "Megaman", email: "megaman@gmail.com")
 
-let mail = Mail(from: drLight,
-                to: [megaman],
-                subject: "Humans and robots living together in harmony and equality.",
-                text: "That was my ultimate wish.")
+let mail = smtp.makeMail(from: drLight,
+                         to: [megaman],
+                         subject: "Humans and robots living together in harmony and equality.",
+                         text: "That was my ultimate wish.")
 
 smtp.send(mail) { (err) in
     if let err = err {
@@ -67,12 +67,12 @@ Add Cc and Bcc:
 let roll = User(name: "Roll", email: "roll@gmail.com")
 let zero = User(name: "Zero", email: "zero@gmail.com")
 
-let mail = Mail(from: drLight,
-                to: [megaman],
-                cc: [roll],
-                bcc: [zero],
-                subject: "Robots should be used for the betterment of mankind.",
-                text: "Any other use would be...unethical.")
+let mail = smtp.makeMail(from: drLight,
+                         to: [megaman],
+                         cc: [roll],
+                         bcc: [zero],
+                         subject: "Robots should be used for the betterment of mankind.",
+                         text: "Any other use would be...unethical.")
 
 smtp.send(mail)
 ```
@@ -99,10 +99,10 @@ let dataAttachment = Attachment(data: data,
                                 inline: false) // send as a standalone attachment
 
 // Create a `Mail` and include the `Attachment`s
-let mail = Mail(from: from, 
-                to: [to], 
-                subject: "Check out this image and JSON file!", 
-                attachments: [htmlAttachment, dataAttachment]) // attachments we created earlier
+let mail = smtp.makeMail(from: from,
+                         to: [to],
+                         subject: "Check out this image and JSON file!",
+                         attachments: [htmlAttachment, dataAttachment]) // attachments we created earlier
 
 // Send the mail
 smtp.send(mail)

--- a/Sources/Mail.swift
+++ b/Sources/Mail.swift
@@ -18,9 +18,14 @@ import Foundation
 
 /// Represents an email that can be sent through an `SMTP` instance.
 public struct Mail {
-    /// UUID of the `Mail`.
-    public let id = UUID().uuidString + ".Swift-SMTP"
+    private let uuid = UUID().uuidString
 
+    /// message-id https://tools.ietf.org/html/rfc5322#section-3.6.4
+    public var id: String {
+        return "<\(uuid).Swift-SMTP@\(hostname)>"
+    }
+
+    let hostname: String
     let from: User
     let to: [User]
     let cc: [User]
@@ -50,7 +55,8 @@ public struct Mail {
     ///                          overwrite each other. Defaults to none. The
     ///                          following will be ignored: CONTENT-TYPE,
     ///                          CONTENT-DISPOSITION, CONTENT-TRANSFER-ENCODING.
-    public init(from: User,
+    public init(hostname: String,
+                from: User,
                 to: [User],
                 cc: [User] = [],
                 bcc: [User] = [],
@@ -58,6 +64,7 @@ public struct Mail {
                 text: String = "",
                 attachments: [Attachment] = [],
                 additionalHeaders: [String: String] = [:]) {
+        self.hostname = hostname
         self.from = from
         self.to = to
         self.cc = cc

--- a/Sources/SMTP.swift
+++ b/Sources/SMTP.swift
@@ -183,4 +183,42 @@ public struct SMTP {
             completion?([], mails.map { ($0, error) })
         }
     }
+
+    /// Returns a `Mail`.
+    ///
+    /// - Parameters:
+    ///     - from: The `User` that the `Mail` will be sent from.
+    ///     - to: Array of `User`s to send the `Mail` to.
+    ///     - cc: Array of `User`s to cc. Defaults to none.
+    ///     - bcc: Array of `User`s to bcc. Defaults to none.
+    ///     - subject: Subject of the `Mail`. Defaults to none.
+    ///     - text: Text of the `Mail`. Defaults to none.
+    ///     - attachments: Array of `Attachment`s for the `Mail`. If the `Mail`
+    ///                    has multiple `Attachment`s that are alternatives to
+    ///                    to plain text, the last one will be used as the
+    ///                    alternative (all the `Attachments` will still be
+    ///                    sent). Defaults to none.
+    ///     - additionalHeaders: Additional headers for the `Mail`. Header keys
+    ///                          are capitalized and duplicate keys will
+    ///                          overwrite each other. Defaults to none. The
+    ///                          following will be ignored: CONTENT-TYPE,
+    ///                          CONTENT-DISPOSITION, CONTENT-TRANSFER-ENCODING.
+    public func makeMail(from: User,
+                         to: [User],
+                         cc: [User] = [],
+                         bcc: [User] = [],
+                         subject: String = "",
+                         text: String = "",
+                         attachments: [Attachment] = [],
+                         additionalHeaders: [String: String] = [:]) -> Mail {
+        return Mail(hostname: hostname,
+                    from: from,
+                    to: to,
+                    cc: cc,
+                    bcc: bcc,
+                    subject: subject,
+                    text: text,
+                    attachments: attachments,
+                    additionalHeaders: additionalHeaders)
+    }
 }

--- a/Tests/SwiftSMTPTests/TestDataSender.swift
+++ b/Tests/SwiftSMTPTests/TestDataSender.swift
@@ -63,7 +63,7 @@ class TestDataSender: XCTestCase {
 
                     if let socket = socket {
                         let attachment = Attachment(data: data, mime: "application/json", name: "file.json")
-                        let mail = Mail(from: from, to: [to], subject: #function, text: text, attachments: [attachment])
+                        let mail = smtp.makeMail(from: from, to: [to], subject: #function, text: text, attachments: [attachment])
 
                         sender = Sender(socket: socket, pending: [mail], progress: nil) { (sent, failed) in
                             XCTAssertEqual(sent.count, 1)
@@ -115,7 +115,7 @@ class TestDataSender: XCTestCase {
 
                     if let socket = socket {
                         let attachment = Attachment(filePath: imgFilePath)
-                        let mail = Mail(from: from, to: [to], subject: #function, text: text, attachments: [attachment])
+                        let mail = smtp.makeMail(from: from, to: [to], subject: #function, text: text, attachments: [attachment])
 
                         sender = Sender(socket: socket, pending: [mail], progress: nil) { (sent, failed) in
                             XCTAssertEqual(sent.count, 1)
@@ -174,7 +174,7 @@ class TestDataSender: XCTestCase {
 
                     if let socket = socket {
                         let attachment = Attachment(htmlContent: html)
-                        let mail = Mail(from: from, to: [to], subject: #function, text: text, attachments: [attachment])
+                        let mail = smtp.makeMail(from: from, to: [to], subject: #function, text: text, attachments: [attachment])
 
                         sender = Sender(socket: socket, pending: [mail], progress: nil) { (sent, failed) in
                             XCTAssertEqual(sent.count, 1)
@@ -201,7 +201,7 @@ class TestDataSender: XCTestCase {
     func testSendData() {
         let x = expectation(description: "Send mail with data attachment.")
         let dataAttachment = Attachment(data: data, mime: "application/json", name: "file.json")
-        let mail = Mail(from: from, to: [to], subject: "Data attachment", text: text, attachments: [dataAttachment])
+        let mail = smtp.makeMail(from: from, to: [to], subject: "Data attachment", text: text, attachments: [dataAttachment])
         smtp.send(mail) { (err) in
             XCTAssertNil(err, String(describing: err))
             x.fulfill()
@@ -212,7 +212,7 @@ class TestDataSender: XCTestCase {
     func testSendFile() {
         let x = expectation(description: "Send mail with file attachment.")
         let fileAttachment = Attachment(filePath: imgFilePath)
-        let mail = Mail(from: from, to: [to], subject: "File attachment", text: text, attachments: [fileAttachment])
+        let mail = smtp.makeMail(from: from, to: [to], subject: "File attachment", text: text, attachments: [fileAttachment])
         smtp.send(mail) { (err) in
             XCTAssertNil(err, String(describing: err))
             x.fulfill()
@@ -223,7 +223,7 @@ class TestDataSender: XCTestCase {
     func testSendHTML() {
         let x = expectation(description: "Send mail with HTML attachment.")
         let htmlAttachment = Attachment(htmlContent: html, alternative: false)
-        let mail = Mail(from: from, to: [to], subject: "HTML attachment", text: text, attachments: [htmlAttachment])
+        let mail = smtp.makeMail(from: from, to: [to], subject: "HTML attachment", text: text, attachments: [htmlAttachment])
         smtp.send(mail) { (err) in
             XCTAssertNil(err, String(describing: err))
             x.fulfill()
@@ -234,7 +234,7 @@ class TestDataSender: XCTestCase {
     func testSendHTMLAlternative() {
         let x = expectation(description: "Send mail with HTML as alternative to text.")
         let htmlAttachment = Attachment(htmlContent: html)
-        let mail = Mail(from: from, to: [to], subject: "HTML alternative attachment", text: text, attachments: [htmlAttachment])
+        let mail = smtp.makeMail(from: from, to: [to], subject: "HTML alternative attachment", text: text, attachments: [htmlAttachment])
         smtp.send(mail) { (err) in
             XCTAssertNil(err, String(describing: err))
             x.fulfill()
@@ -246,7 +246,7 @@ class TestDataSender: XCTestCase {
         let x = expectation(description: "Send mail with multiple attachments.")
         let fileAttachment = Attachment(filePath: imgFilePath)
         let htmlAttachment = Attachment(htmlContent: html, alternative: false)
-        let mail = Mail(from: from, to: [to], subject: "Multiple attachments", text: text, attachments: [fileAttachment, htmlAttachment])
+        let mail = smtp.makeMail(from: from, to: [to], subject: "Multiple attachments", text: text, attachments: [fileAttachment, htmlAttachment])
         smtp.send(mail) { (err) in
             XCTAssertNil(err, String(describing: err))
             x.fulfill()
@@ -256,7 +256,7 @@ class TestDataSender: XCTestCase {
 
     func testSendNonASCII() {
         let x = expectation(description: "Send mail with non ASCII character.")
-        let mail = Mail(from: from, to: [to], subject: "Non ASCII", text: "💦")
+        let mail = smtp.makeMail(from: from, to: [to], subject: "Non ASCII", text: "💦")
         smtp.send(mail) { (err) in
             XCTAssertNil(err, String(describing: err))
             x.fulfill()
@@ -268,7 +268,7 @@ class TestDataSender: XCTestCase {
         let x = expectation(description: "Send mail with an attachment that references a related attachment.")
         let fileAttachment = Attachment(filePath: imgFilePath, additionalHeaders: ["CONTENT-ID": "megaman-pic"])
         let htmlAttachment = Attachment(htmlContent: "<html><img src=\"cid:megaman-pic\"/>\(text)</html>", relatedAttachments: [fileAttachment])
-        let mail = Mail(from: from, to: [to], subject: "HTML with related attachment", text: text, attachments: [htmlAttachment])
+        let mail = smtp.makeMail(from: from, to: [to], subject: "HTML with related attachment", text: text, attachments: [htmlAttachment])
         smtp.send(mail) { (err) in
             XCTAssertNil(err, String(describing: err))
             x.fulfill()

--- a/Tests/SwiftSMTPTests/TestMiscellaneous.swift
+++ b/Tests/SwiftSMTPTests/TestMiscellaneous.swift
@@ -64,7 +64,7 @@ extension TestMiscellaneous {
     }
 
     func testMailHeaders() {
-        let headers = Mail(from: from, to: [to], cc: [to2], subject: "Test", text: text, additionalHeaders: ["header": "val"]).headersString
+        let headers = smtp.makeMail(from: from, to: [to], cc: [to2], subject: "Test", text: text, additionalHeaders: ["header": "val"]).headersString
 
         let to_ = "TO: =?UTF-8?Q?Megaman?= <\(email)>"
         XCTAssert(headers.contains(to_), "Mail header did not contain \(to_)")

--- a/Tests/SwiftSMTPTests/TestSender.swift
+++ b/Tests/SwiftSMTPTests/TestSender.swift
@@ -40,7 +40,7 @@ class TestSender: XCTestCase {
     func testBadEmail() {
         let x = expectation(description: "Send a mail that will fail because of an invalid receiving address.")
         let user = User(email: "")
-        let mail = Mail(from: user, to: [user])
+        let mail = smtp.makeMail(from: user, to: [user])
         smtp.send(mail) { (err) in
             XCTAssertNotNil(err, "Sending mail to an invalid email address should return an error, but return nil.")
             x.fulfill()
@@ -63,7 +63,7 @@ class TestSender: XCTestCase {
         let x = expectation(description: #function)
         defer { waitForExpectations(timeout: testDuration) }
 
-        let mail = Mail(from: from, to: [to], subject: "Simple email", text: text)
+        let mail = smtp.makeMail(from: from, to: [to], subject: #function, text: text)
         smtp.send(mail) { (err) in
             XCTAssertNil(err, String(describing: err))
             x.fulfill()
@@ -74,7 +74,7 @@ class TestSender: XCTestCase {
         let x = expectation(description: #function)
         defer { waitForExpectations(timeout: testDuration) }
 
-        let mail = Mail(from: from, to: [to], subject: "Simple email", text: text)
+        let mail = smtp.makeMail(from: from, to: [to], subject: #function, text: text)
         smtp.send([mail]) { (sent, failed) in
             XCTAssert(failed.isEmpty)
             x.fulfill()
@@ -85,7 +85,7 @@ class TestSender: XCTestCase {
         let x = expectation(description: #function)
         defer { waitForExpectations(timeout: testDuration) }
 
-        let mail = Mail(from: from, to: [], subject: "Simple email", text: text)
+        let mail = smtp.makeMail(from: from, to: [], subject: #function, text: text)
         smtp.send([mail]) { (err) in
             if let err = err.1[0].1 as? SMTPError, case .noRecipients = err {
                 x.fulfill()
@@ -108,8 +108,9 @@ class TestSender: XCTestCase {
 
     func testSendMailsConcurrently() {
         let x = expectation(description: "Send multiple mails concurrently with seperate calls to `send`.")
-        let mail1 = Mail(from: from, to: [to], subject: "Send mails concurrently 1")
-        let mail2 = Mail(from: from, to: [to], subject: "Send mails concurrently 2")
+
+        let mail1 = smtp.makeMail(from: from, to: [to], subject: "Send mails concurrently 1")
+        let mail2 = smtp.makeMail(from: from, to: [to], subject: "Send mails concurrently 2")
         let mails = [mail1, mail2]
         let group = DispatchGroup()
 
@@ -129,7 +130,7 @@ class TestSender: XCTestCase {
 
     func testSendMailWithCc() {
         let x = expectation(description: "Send mail with Cc.")
-        let mail = Mail(from: from, to: [to], cc: [to2], subject: "Mail with Cc")
+        let mail = smtp.makeMail(from: from, to: [to], cc: [to2], subject: #function)
         smtp.send(mail) { (err) in
             XCTAssertNil(err, String(describing: err))
             x.fulfill()
@@ -139,7 +140,7 @@ class TestSender: XCTestCase {
 
     func testSendMailWithBcc() {
         let x = expectation(description: "Send mail with Bcc.")
-        let mail = Mail(from: from, to: [to], bcc: [to2], subject: "Mail with Bcc")
+        let mail = smtp.makeMail(from: from, to: [to], bcc: [to2], subject: #function)
         smtp.send(mail) { (err) in
             XCTAssertNil(err, String(describing: err))
             x.fulfill()
@@ -149,8 +150,8 @@ class TestSender: XCTestCase {
 
     func testSendMultipleMails() {
         let x = expectation(description: "Send multiple mails with one call to `send`.")
-        let mail1 = Mail(from: from, to: [to], subject: "Send multiple mails 1")
-        let mail2 = Mail(from: from, to: [to], subject: "Send multiple mails 2")
+        let mail1 = smtp.makeMail(from: from, to: [to], subject: "Send multiple mails 1")
+        let mail2 = smtp.makeMail(from: from, to: [to], subject: "Send multiple mails 2")
         smtp.send([mail1, mail2], progress: { (_, err) in
             XCTAssertNil(err, String(describing: err))
         }) { (sent, failed) in
@@ -164,8 +165,8 @@ class TestSender: XCTestCase {
     func testSendMultipleMailsWithFail() {
         let x = expectation(description: "Send two mails, one of which will fail.")
         let badUser = User(email: "")
-        let badMail = Mail(from: from, to: [badUser])
-        let goodMail = Mail(from: from, to: [to], subject: "Send multiple mails with fail")
+        let badMail = smtp.makeMail(from: from, to: [badUser])
+        let goodMail = smtp.makeMail(from: from, to: [to], subject: "Send multiple mails with fail")
 
         smtp.send([badMail, goodMail]) { (sent, failed) in
             guard sent.count == 1 && failed.count == 1 else {
@@ -183,7 +184,7 @@ class TestSender: XCTestCase {
 
     func testSendMultipleRecipients() {
         let x = expectation(description: "Send a single mail to multiple recipients.")
-        let mail = Mail(from: from, to: [to, to2], subject: "Multiple recipients")
+        let mail = smtp.makeMail(from: from, to: [to, to2], subject: #function)
         smtp.send(mail) { (err) in
             XCTAssertNil(err, String(describing: err))
             x.fulfill()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Fixes #41.
- Introduces necessary breaking API changes to the initialization of a `Mail` object--an additional parameter is required: `hostname`.
- Introduces a new API in the `SMTP` struct: `makeMail()`, that allows the user to create a `Mail` object without specifying a hostname--it will be the same as the`SMTP` instance's.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
