### PR TITLE
Correct incorrect init label

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ import SwiftSMTP
 
 // Create your `SMTP` handle
 let smtp = SMTP(hostname: "smtp.gmail.com",     // SMTP server address
-                user: "user@gmail.com",         // username to login 
+                email: "user@gmail.com",         // username to login 
                 password: "password")           // password to login
                 
 /* Additional parameters available to further customize your `SMTP` handle */


### PR DESCRIPTION
README.md had an issue  where the SMTP init label was "user" instead of "email"