### PR TITLE
Use 'text/plain' for plain text content

### DIFF
--- a/Sources/SwiftSMTP/DataSender.swift
+++ b/Sources/SwiftSMTP/DataSender.swift
@@ -222,7 +222,7 @@ private extension String {
     // rendered correctly.
     var embedded: String {
         var embeddedText = ""
-        embeddedText += "CONTENT-TYPE: text/html; charset=utf-8\(CRLF)"
+        embeddedText += "CONTENT-TYPE: text/plain; charset=utf-8\(CRLF)"
         embeddedText += "CONTENT-TRANSFER-ENCODING: 7bit\(CRLF)"
         embeddedText += "CONTENT-DISPOSITION: inline\(CRLF)"
         embeddedText += "\(CRLF)\(self)\(CRLF)"


### PR DESCRIPTION
The previous usage of 'text/html' causes some mail clients (notably
Outlook.com) to incorrectly render the plain text content as if it was
the attached HTML content (if one is present).

## Description
Swapped 'text/html' for 'text/plain' for plain text content in DataSender.swift

## Motivation and Context
Some mail clients (tested with Outlook.com) incorrectly render the plain text content as if it was HTML. if there was HTML content attached, it will not be displayed.

## How Has This Been Tested?
Verified emails render correctly in macOS Mail.app, Outlook.com, and Gmail.com

## Checklist:
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.