### PR TITLE
fixing User namespace issue

### DIFF
--- a/Sources/SwiftSMTP/Mail.swift
+++ b/Sources/SwiftSMTP/Mail.swift
@@ -18,6 +18,22 @@ import Foundation
 
 /// Represents an email that can be sent through an `SMTP` instance.
 public struct Mail {
+    /// Represents a sender or receiver of an email.
+    public struct User {
+        private let name: String?
+        let email: String
+        
+        ///  Initializes a `User`.
+        ///
+        /// - Parameters:
+        ///     - name: Display name for the user. (optional)
+        ///     - email: Email address for the user.
+        public init(name: String? = nil, email: String) {
+            self.name = name
+            self.email = email
+        }
+    }
+
     /// A UUID for the mail.
     public let uuid = UUID().uuidString
     /// The `User` that the `Mail` will be sent from.
@@ -138,6 +154,16 @@ extension Mail {
 extension Mail {
     var hasAttachment: Bool {
         return !attachments.isEmpty || alternative != nil
+    }
+}
+
+extension Mail.User {
+    var mime: String {
+        if let name = name, let nameEncoded = name.mimeEncoded {
+            return "\(nameEncoded) <\(email)>"
+        } else {
+            return email
+        }
     }
 }
 

--- a/Sources/SwiftSMTP/User.swift
+++ b/Sources/SwiftSMTP/User.swift
@@ -16,28 +16,5 @@
 
 import Foundation
 
-/// Represents a sender or receiver of an email.
-public struct User {
-    private let name: String?
-    let email: String
-    
-    ///  Initializes a `User`.
-    ///
-    /// - Parameters:
-    ///     - name: Display name for the user. (optional)
-    ///     - email: Email address for the user.
-    public init(name: String? = nil, email: String) {
-        self.name = name
-        self.email = email
-    }
-}
 
-extension User {
-    var mime: String {
-        if let name = name, let nameEncoded = name.mimeEncoded {
-            return "\(nameEncoded) <\(email)>"
-        } else {
-            return email
-        }
-    }
-}
+

--- a/Tests/SwiftSMTPTests/Constant.swift
+++ b/Tests/SwiftSMTPTests/Constant.swift
@@ -82,9 +82,9 @@ let tlsConfiguration = TLSConfiguration(withChainFilePath: cert, withPassword: c
 #endif
 
 let smtp = SMTP(hostname: hostname, email: email, password: password)
-let from = User(name: "Dr. Light", email: email)
-let to = User(name: "Megaman", email: email)
-let to2 = User(name: "Roll", email: email)
+let from = Mail.User(name: "Dr. Light", email: email)
+let to = Mail.User(name: "Megaman", email: email)
+let to2 = Mail.User(name: "Roll", email: email)
 let text = "Humans and robots living together in harmony and equality: That was my ultimate wish."
 let html = "<html><img src=\"http://vignette2.wikia.nocookie.net/megaman/images/4/40/StH250RobotMasters.jpg/revision/latest?cb=20130711161323\"/></html>"
 let imgFilePath = testsDir + "/x.png"

--- a/Tests/SwiftSMTPTests/TestMailSender.swift
+++ b/Tests/SwiftSMTPTests/TestMailSender.swift
@@ -38,7 +38,7 @@ class TestMailSender: XCTestCase {
 
     func testBadEmail() {
         let x = expectation(description: "Send a mail that will fail because of an invalid receiving address.")
-        let user = User(email: "")
+        let user = Mail.User(email: "")
         let mail = Mail(from: user, to: [user])
         smtp.send(mail) { (err) in
             XCTAssertNotNil(err, "Sending mail to an invalid email address should return an error, but return nil.")
@@ -147,7 +147,7 @@ class TestMailSender: XCTestCase {
 
     func testSendMultipleMailsWithFail() {
         let x = expectation(description: "Send two mails, one of which will fail.")
-        let badUser = User(email: "")
+        let badUser = Mail.User(email: "")
         let badMail = Mail(from: from, to: [badUser])
         let goodMail = Mail(from: from, to: [to], subject: "Send multiple mails with fail")
         smtp.send([badMail, goodMail]) { (sent, failed) in

--- a/Tests/SwiftSMTPTests/TestMiscellaneous.swift
+++ b/Tests/SwiftSMTPTests/TestMiscellaneous.swift
@@ -117,13 +117,13 @@ extension TestMiscellaneous {
 // User
 extension TestMiscellaneous {
     func testMimeNoName() {
-        let user = User(email: "bob@gmail.com")
+        let user = Mail.User(email: "bob@gmail.com")
         let expected = "bob@gmail.com"
         XCTAssertEqual(user.mime, expected, "result: \(user.mime) != expected: \(expected)")
     }
 
     func testMimeWithName() {
-        let user = User(name: "Bob", email: "bob@gmail.com")
+        let user = Mail.User(name: "Bob", email: "bob@gmail.com")
         let expected = "=?UTF-8?Q?Bob?= <bob@gmail.com>"
         XCTAssertEqual(user.mime, expected, "result: \(user.mime) != expected: \(expected)")
     }


### PR DESCRIPTION
As User is a very common model name, there is a potential (very real for me really) issue of a clash with another module. The problem is that if you need to create a User where SwiftSMTP is imported too while you have a class matching the namespace in other framework, you will never be able to address the other user using the namespace prefix.

There is a bug report on this here: 
https://bugs.swift.org/browse/SR-5304

I know this would be a breaking PR and would probably need some additional cleaning but it would be amazing your take on this.

Thanks :)