### PR TITLE
Fix getting alternative attachment

### DIFF
--- a/Sources/SwiftSMTP/Mail.swift
+++ b/Sources/SwiftSMTP/Mail.swift
@@ -92,8 +92,7 @@ public struct Mail {
     }
 
     private static func getAlternative(_ attachments: [Attachment]) -> (Attachment?, [Attachment]) {
-        let reversed: [Attachment] = attachments.reversed()
-        if let index = reversed.index(where: {( $0.isAlternative )}) {
+        if let index = attachments.index(where: {( $0.isAlternative )}) {
             var newAttachments = attachments
             return (newAttachments.remove(at: index), newAttachments)
         }

--- a/Tests/SwiftSMTPTests/TestAttachment.swift
+++ b/Tests/SwiftSMTPTests/TestAttachment.swift
@@ -22,7 +22,8 @@ class TestAttachment: XCTestCase {
         return [
             ("testDataAttachmentHeaders", testDataAttachmentHeaders),
             ("testFileAttachmentHeaders", testFileAttachmentHeaders),
-            ("testHTMLAttachmentHeaders", testHTMLAttachmentHeaders)
+            ("testHTMLAttachmentHeaders", testHTMLAttachmentHeaders),
+            ("testAlternativeAttachment", testAlternativeAttachment)
         ]
     }
 
@@ -48,5 +49,17 @@ class TestAttachment: XCTestCase {
         XCTAssert(headers.contains("CONTENT-DISPOSITION: inline"))
         XCTAssert(headers.contains("CONTENT-TRANSFER-ENCODING: BASE64"))
 
+    }
+
+    func testAlternativeAttachment() {
+        let data = "{\"key\": \"hello world\"}".data(using: .utf8)!
+        let imgAttachment = Attachment(filePath: imgFilePath, additionalHeaders: ["CONTENT-ID": "megaman-pic"])
+        let htmlAttachment = Attachment(htmlContent: "<html><img src=\"cid:megaman-pic\"/>\(text)</html>", relatedAttachments: [imgAttachment])
+        let jsonAttachment = Attachment(data: data, mime: "application/json", name: "file.json")
+        let mail = Mail(from: from, to: [to], subject: "HTML with related attachment, plus additional attachment", text: text, attachments: [htmlAttachment, jsonAttachment])
+
+        XCTAssert(htmlAttachment.isAlternative)
+        XCTAssert(!jsonAttachment.isAlternative)
+        XCTAssert(mail.alternative!.isAlternative)
     }
 }


### PR DESCRIPTION
## Description
Mail's 'getAlternative(_)' was looking for alternative attachments by counting from the back of the attachments array. The index was then used to remove the attachment by counting from the front of the array. This resulted in the wrong attachment being returned as the 'alternative' one.

This pull request fixes the above, and returns the **first** alternative attachment found in a Mail's array of attachments when an alternative is requested.

## Motivation and Context
Sending plain-text mails with an alternative HTML attachment and additional attachments would incorrectly pack one of the additional attachments as the plain-text's "alternative". Various mail clients expect the nesting of mail parts to be correct in order to display the mail correctly. Mails with the attachments described would fail to render correctly in some clients because their message structure was incorrect.

## How Has This Been Tested?
Examined mails with HTML alternatives, with and without additional attachments, in various Mail clients.
Added an additional test case in TestAttachment.swift to verify the correct attachment is returned when requesting a Mail's alternative.

## Checklist:
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.