### PR TITLE
Starttls

### DIFF
--- a/Sources/SwiftSMTP/SMTP.swift
+++ b/Sources/SwiftSMTP/SMTP.swift
@@ -22,11 +22,23 @@ public struct SMTP {
     private let email: String
     private let password: String
     private let port: Int32
-    private let useTLS: Bool
+    private let tlsMode: TLSMode
     private let tlsConfiguration: TLSConfiguration?
     private let authMethods: [String: AuthMethod]
     private let domainName: String
     private let timeout: UInt
+
+    /// TLSMode enum for what form of connection security to enforce
+    public enum TLSMode {
+        /// Follow the requirements of the server with no enforced security. Initiated with no TLS
+        case normal
+        /// Do not use TLS. Ignore any commands to upgrade to TLS
+        case noTLS
+        /// Require TLS from the initial connection
+        case requireTLS
+        /// Enforce the connection upgrades to TLS
+        case requireSTARTTLS
+    }
 
     /// Initializes an `SMTP` instance.
     ///
@@ -35,8 +47,7 @@ public struct SMTP {
     ///     - email: Username to log in to server.
     ///     - password: Password to log in to server, or access token if using XOAUTH2 authorization method.
     ///     - port: Port to connect to the server on. Defaults to `465`.
-    ///     - useTLS: `Bool` indicating whether to connect with TLS. Your server must support the `STARTTLS` command.
-    ///       Defaults to `true`.
+    ///     - tlsMode: TLSMode `enum` indicating what form of connection security to use
     ///     - tlsConfiguration: `TLSConfiguration` used to connect with TLS. If nil, a configuration with no backing
     ///       certificates is used. See `TLSConfiguration` for other configuration options.
     ///     - authMethods: `AuthMethod`s to use to log in to the server. If blank, tries all supported methods.
@@ -50,8 +61,8 @@ public struct SMTP {
     public init(hostname: String,
                 email: String,
                 password: String,
-                port: Int32 = 465,
-                useTLS: Bool = true,
+                port: Int32 = 587,
+                tlsMode: TLSMode = .requireSTARTTLS,
                 tlsConfiguration: TLSConfiguration? = nil,
                 authMethods: [AuthMethod] = [],
                 domainName: String = "localhost",
@@ -60,7 +71,7 @@ public struct SMTP {
         self.email = email
         self.password = password
         self.port = port
-        self.useTLS = useTLS
+        self.tlsMode = tlsMode
         self.tlsConfiguration = tlsConfiguration
 
         let _authMethods = !authMethods.isEmpty ? authMethods : [
@@ -126,7 +137,7 @@ public struct SMTP {
                 email: email,
                 password: password,
                 port: port,
-                useTLS: useTLS,
+                tlsMode: tlsMode,
                 tlsConfiguration: tlsConfiguration,
                 authMethods: authMethods,
                 domainName: domainName,

--- a/Sources/SwiftSMTP/SMTP.swift
+++ b/Sources/SwiftSMTP/SMTP.swift
@@ -30,13 +30,16 @@ public struct SMTP {
 
     /// TLSMode enum for what form of connection security to enforce
     public enum TLSMode {
-        /// Follow the requirements of the server with no enforced security. Initiated with no TLS
+        /// Upgrades the connection to TLS if STARTLS command is received, else sends mail without security.
         case normal
-        /// Do not use TLS. Ignore any commands to upgrade to TLS
-        case noTLS
-        /// Require TLS from the initial connection
+
+        /// Send mail over plaintext and ignore STARTTLS commands and TLS options. Could throw an error if server requires TLS.
+        case ignoreTLS
+
+        /// Only send mail after an initial successful TLS connection. Connection will fail if a TLS connection cannot be established.
         case requireTLS
-        /// Enforce the connection upgrades to TLS
+
+        /// Expect a STARTTLS command from the server and require the connection is upgraded to TLS. Will throw if the server does not issue a STARTTLS command
         case requireSTARTTLS
     }
 

--- a/Sources/SwiftSMTP/SMTPError.swift
+++ b/Sources/SwiftSMTP/SMTPError.swift
@@ -50,6 +50,9 @@ public enum SMTPError: Error, CustomStringConvertible {
     // User
     /// Invalid email provided for `User`.
     case invalidEmail(email: String)
+
+    /// STARTTLS was required but the server did not request it
+    case requireSTARTTLS
     
     /// Description of the `SMTPError`.
     public var description: String {
@@ -63,6 +66,7 @@ public enum SMTPError: Error, CustomStringConvertible {
         case .badResponse(let command, let response): return "Bad response received for command. command: (\(command)), response: \(response)"
         case .convertDataUTF8Fail(let buf): return "Error converting Data read from socket to a String: \(buf)."
         case .invalidEmail(let email): return "Invalid email provided for User: \(email)."
+        case .requireSTARTTLS: return "STARTTLS was required but the server did not issue a STARTTLS command."
         }
     }
 

--- a/Sources/SwiftSMTP/SMTPError.swift
+++ b/Sources/SwiftSMTP/SMTPError.swift
@@ -52,7 +52,7 @@ public enum SMTPError: Error, CustomStringConvertible {
     case invalidEmail(email: String)
 
     /// STARTTLS was required but the server did not request it
-    case requireSTARTTLS
+    case requiredSTARTTLS
     
     /// Description of the `SMTPError`.
     public var description: String {
@@ -66,7 +66,7 @@ public enum SMTPError: Error, CustomStringConvertible {
         case .badResponse(let command, let response): return "Bad response received for command. command: (\(command)), response: \(response)"
         case .convertDataUTF8Fail(let buf): return "Error converting Data read from socket to a String: \(buf)."
         case .invalidEmail(let email): return "Invalid email provided for User: \(email)."
-        case .requireSTARTTLS: return "STARTTLS was required but the server did not issue a STARTTLS command."
+        case .requiredSTARTTLS: return "STARTTLS was required but the server did not issue a STARTTLS command."
         }
     }
 

--- a/Sources/SwiftSMTP/SMTPSocket.swift
+++ b/Sources/SwiftSMTP/SMTPSocket.swift
@@ -41,11 +41,11 @@ struct SMTPSocket {
         try socket.connect(to: hostname, port: port, timeout: timeout * 1000)
         try parseResponses(readFromSocket(), command: .connect)
         var serverOptions = try getServerOptions(domainName: domainName)
-        if (tlsMode == .normal || tlsMode == .requireSTARTTLS) {
+        if (tlsMode == .requireSTARTTLS || tlsMode == .normal) {
             if (try doStarttls(serverOptions: serverOptions, tlsConfiguration:tlsConfiguration)) {
                 serverOptions = try getServerOptions(domainName: domainName)
             } else if (tlsMode == .requireSTARTTLS) {
-                throw SMTPError.requireSTARTTLS
+                throw SMTPError.requiredSTARTTLS
             }
         }
         let authMethod = try getAuthMethod(authMethods: authMethods, serverOptions: serverOptions, hostname: hostname)


### PR DESCRIPTION
Addresses https://github.com/IBM-Swift/Swift-SMTP/issues/79 and should also address https://github.com/IBM-Swift/Swift-SMTP/issues/65

Also updates default SMTP initiator to require STARTTLS upgrade and to use port 587.

This has been tested against postfix, gmail and outlook.