### PR TITLE
Feature/107 no auth connect

### DIFF
--- a/Sources/SwiftSMTP/AuthMethod.swift
+++ b/Sources/SwiftSMTP/AuthMethod.swift
@@ -26,4 +26,6 @@ public enum AuthMethod: String {
     case plain = "PLAIN"
     /// XOAUTH2 authentication. Requires a valid access token.
     case xoauth2 = "XOAUTH2"
+    /// No authentication at all
+    case none = "NONE"
 }

--- a/Sources/SwiftSMTP/Command.swift
+++ b/Sources/SwiftSMTP/Command.swift
@@ -62,6 +62,7 @@ enum Command {
             case .login: return [.containingChallenge]
             case .plain: return [.authSucceeded]
             case .xoauth2: return [.authSucceeded]
+            case .none: return [.commandOK]
             }
         case .authUser: return [.containingChallenge]
         case .authPassword: return [.authSucceeded]

--- a/Sources/SwiftSMTP/SMTP.swift
+++ b/Sources/SwiftSMTP/SMTP.swift
@@ -93,6 +93,39 @@ public struct SMTP {
         self.timeout = timeout
     }
 
+    /// Initializes an `SMTP` instance, specifically for use when communicating with an SMTP
+    /// host which does not perform authentication.
+    ///
+    /// - Parameters:
+    ///     - hostname: Hostname of the SMTP server to connect to, i.e. `smtp.example.com`.
+    ///     - port: Port to connect to the server on. Defaults to `465`.
+    ///     - tlsMode: TLSMode `enum` indicating what form of connection security to use.
+    ///     - tlsConfiguration: `TLSConfiguration` used to connect with TLS. If nil, a configuration with no backing
+    ///       certificates is used. See `TLSConfiguration` for other configuration options.
+    ///     - domainName: Client domain name used when communicating with the server. Defaults to `localhost`.
+    ///     - timeout: How long to try connecting to the server to before returning an error. Defaults to `10` seconds.
+    ///
+    /// - Note:
+    ///     - You may need to enable access for less secure apps for your account on the SMTP server.
+    ///     - Some servers like Gmail support IPv6, and if your network does  not, you will first attempt to connect via
+    ///       IPv6, then timeout, and fall back to IPv4. You can avoid this by disabling IPv6 on your machine.
+    public init(hostname: String,
+                port: Int32 = 587,
+                tlsMode: TLSMode = .requireSTARTTLS,
+                tlsConfiguration: TLSConfiguration? = nil,
+                domainName: String = "localhost",
+                timeout: UInt = 10) {
+        self.hostname = hostname
+        self.email = ""
+        self.password = ""
+        self.port = port
+        self.tlsMode = tlsMode
+        self.tlsConfiguration = tlsConfiguration
+        self.authMethods = [String: AuthMethod]()
+        self.domainName = domainName
+        self.timeout = timeout
+    }
+
     /// Send an email.
     ///
     /// - Parameters:

--- a/Sources/SwiftSMTP/SMTP.swift
+++ b/Sources/SwiftSMTP/SMTP.swift
@@ -178,7 +178,28 @@ public struct SMTP {
                 authMethods: authMethods,
                 domainName: domainName,
                 timeout: timeout
-            )
+            let socket = if !authMethods.isEmpty {
+                 try SMTPSocket(
+                     hostname: hostname,
+                     email: email,
+                     password: password,
+                     port: port,
+                     tlsMode: tlsMode,
+                     tlsConfiguration: tlsConfiguration,
+                     authMethods: authMethods,
+                     domainName: domainName,
+                     timeout: timeout
+                 )
+             } else {
+                 try SMTPSocket(
+                     hostname: hostname,
+                     port: port,
+                     tlsMode: tlsMode,
+                     tlsConfiguration: tlsConfiguration,
+                     domainName: domainName,
+                     timeout: timeout
+                 )
+             }
             MailSender(
                 socket: socket,
                 mailsToSend: mails,

--- a/Tests/SwiftSMTPTests/Constant.swift
+++ b/Tests/SwiftSMTPTests/Constant.swift
@@ -29,7 +29,7 @@ let noAuthHost: String? = "localhost"
 let noAuthPort: Int32 = 1081
 
 let hostname = "mail.kitura.dev"
-let myEmail: String? = "tester@local"
+let myEmail: String? = nil
 let myPassword: String? = nil
 let portTLS: Int32 = 465
 let portPlain: Int32 = 2525

--- a/Tests/SwiftSMTPTests/Constant.swift
+++ b/Tests/SwiftSMTPTests/Constant.swift
@@ -25,8 +25,11 @@ let testDuration: Double = 15
 
 // 📧📧📧 Fill in your own SMTP login info for local testing
 // ⚠️⚠️⚠️ DO NOT CHECK IN YOUR EMAIL CREDENTALS!!!
+let noAuthHost: String? = "localhost"
+let noAuthPort: Int32 = 1081
+
 let hostname = "mail.kitura.dev"
-let myEmail: String? = nil
+let myEmail: String? = "tester@local"
 let myPassword: String? = nil
 let portTLS: Int32 = 465
 let portPlain: Int32 = 2525

--- a/Tests/SwiftSMTPTests/TestMailSender.swift
+++ b/Tests/SwiftSMTPTests/TestMailSender.swift
@@ -57,6 +57,23 @@ class TestMailSender: XCTestCase {
             x.fulfill()
         }
     }
+
+    func testSendMailNoAuth() throws {
+        let x = expectation(description: #function)
+        defer { waitForExpectations(timeout: testDuration) }
+
+        let mail = Mail(from: from, to: [to], subject: #function, text: text)
+        if let theHost = noAuthHost {
+            let noAuthSMTP = SMTP(hostname: theHost, port: noAuthPort, tlsMode: .ignoreTLS,
+                                  tlsConfiguration: .none)
+            noAuthSMTP.send(mail) { (err) in
+                XCTAssertNil(err, String(describing: err))
+                x.fulfill()
+            }
+        } else {
+            throw XCTSkip("No no-auth SMTP server configured")
+        }
+    }
     
     func testSendMailInArray() {
         let x = expectation(description: #function)

--- a/Tests/SwiftSMTPTests/TestSMTPSocket.swift
+++ b/Tests/SwiftSMTPTests/TestSMTPSocket.swift
@@ -19,6 +19,7 @@ import XCTest
 
 class TestSMTPSocket: XCTestCase {
     static var allTests = [
+        ("testNoAuth", testNoAuth),
         ("testBadCredentials", testBadCredentials),
         ("testBadPort", testBadPort),
         ("testLogin", testLogin),
@@ -26,6 +27,33 @@ class TestSMTPSocket: XCTestCase {
         ("testPort0", testPort0),
         ("testSSL", testSSL)
     ]
+
+    func testNoAuth() throws {
+        if let noAuthHost = noAuthHost {
+            let x = expectation(description: #function)
+            defer { waitForExpectations(timeout: testDuration) }
+
+            do {
+                _ = try SMTPSocket(
+                    hostname: noAuthHost,
+                    email: email,
+                    password: "don't care",
+                    port: noAuthPort,
+                    tlsMode: .ignoreTLS,
+                    tlsConfiguration: nil,
+                    authMethods: [String: AuthMethod](),
+                    domainName: domainName,
+                    timeout: timeout
+                )
+                x.fulfill()
+            } catch {
+                XCTFail(String(describing: error))
+                x.fulfill()
+            }
+        } else {
+            throw XCTSkip("No no-auth SMTP server configured")
+        }
+    }
 
     func testBadCredentials() throws {
         let x = expectation(description: #function)

--- a/Tests/SwiftSMTPTests/TestSMTPSocket.swift
+++ b/Tests/SwiftSMTPTests/TestSMTPSocket.swift
@@ -36,12 +36,9 @@ class TestSMTPSocket: XCTestCase {
             do {
                 _ = try SMTPSocket(
                     hostname: noAuthHost,
-                    email: email,
-                    password: "don't care",
                     port: noAuthPort,
                     tlsMode: .ignoreTLS,
                     tlsConfiguration: nil,
-                    authMethods: [String: AuthMethod](),
                     domainName: domainName,
                     timeout: timeout
                 )


### PR DESCRIPTION
Fix issue #107 by only trying to authenticate if the server advertises the AUTH extended capability.

## Description
During socket initialization, we will check to see if the server even supports AUTH before we attempt to perform a login.

## Motivation and Context
Not every SMTP server requires authentication. If you try to use this library to connect to one such, you will have no luck. A trivial real-world use case for this would be a docker container that's running an open SMTP relay but which is only accessible to an application server running in a different container. It seems strange for an SMTP **client** library to enforce a server's authentication policy, and to limit itself to connecting only to servers which support an optional command.

Fixes issue #107 

## How Has This Been Tested?
Running an open, ["dummy" SMTP](https://github.com/rjo1970/dumbster) server locally, I tried to connect an SMTPSocket to it. Initially, since the server did not advertise an AUTH capability, this threw an exception. After the change, the connection succeeded.

## Checklist:
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have added tests to cover my changes.
