### PR TITLE
Use `LoggerAPI` debug logging instead of `print` in `DataSender`

### DIFF
--- a/Sources/SwiftSMTP/DataSender.swift
+++ b/Sources/SwiftSMTP/DataSender.swift
@@ -15,6 +15,7 @@
  **/
 
 import Foundation
+import LoggerAPI
 
 // Used to send the content of an email--headers, text, and attachments.
 // Should only be invoked after sending the `DATA` command to the server.
@@ -200,13 +201,13 @@ extension DataSender {
 private extension DataSender {
     // Write `text` to the socket.
     func send(_ text: String) throws {
-        print("SEND: \(text)")
+        Log.debug("SEND: \(text)")
         try socket.write(text)
     }
 
     // Write `data` to the socket.
     func send(_ data: Data) throws {
-        print("SEND: data \(data.count) bytes")
+        Log.debug("SEND: data \(data.count) bytes")
         try socket.write(data)
     }
 }


### PR DESCRIPTION
The goal of this change is to make is to avoid unnecessary logging of potentially sensitive data to stdout while still offering the freedom to output this for debugging purposes.

## Description

The change is a pretty simple one. It switches from using the `print` statement to using `LoggerAPI`. This matches what I can see elsewhere in the project and hopefully the overall intent.

## Motivation and Context

Right now all data sent is printed to stdout which is useful when debugging but potentially leaks sensitive user data when used in larger production environments.

## How Has This Been Tested?

This code has been manually tested on Linux and macOS.

The only potential problem I could foresee with this change is if tools are relying on this stdout for any kind of logging analytics in production environments.

## Checklist:
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.

~~I've tried to sign a CLA but it seems the email address listed to submit it is now bouncing. I guess Vince Herrin maybe doesn't work at IBM any more?~~