### PR TITLE
Add PGP/MIME support and in-memory message rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 Package.resolved
 /*.xcodeproj
 .swiftpm
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -193,6 +193,84 @@ smtp.send([mail1, mail2],
 )
 ```
 
+### Send a PGP/MIME encrypted message
+
+Swift-SMTP can frame an [RFC 3156](https://datatracker.ietf.org/doc/html/rfc3156) `multipart/encrypted` body when `Mail.pgp` is set. Encryption itself is **out of scope** — bring your own OpenPGP implementation (e.g. ObjectivePGP). The library's job is the MIME envelope: it labels the body `multipart/encrypted; protocol="application/pgp-encrypted"` and emits the two body parts in order, refusing to emit `Mail.text` so plaintext cannot leak alongside the ciphertext.
+
+RFC 3156 §4 requires exactly two body parts:
+
+1. `application/pgp-encrypted` containing `Version: 1`
+2. The ASCII-armored ciphertext (typically `application/octet-stream`)
+
+Both parts are supplied by the caller as `Attachment`s, in that order:
+
+```swift
+// 1. The required Version part.
+let versionPart = Attachment(
+    pgp: "Version: 1",
+    mime: "application/pgp-encrypted",
+    name: ""
+)
+
+// 2. The ciphertext. `cipherText` is the ASCII-armored output of your PGP
+//    encryption step ("-----BEGIN PGP MESSAGE----- ... -----END PGP MESSAGE-----").
+let ciphertextPart = Attachment(
+    pgp: cipherText,
+    mime: "application/octet-stream",
+    name: "encrypted.asc"
+)
+
+let mail = Mail(
+    from: alice,
+    to: [bob],
+    subject: "Encrypted message",
+    text: "",                // ignored when pgp:true
+    pgp: true,
+    attachments: [versionPart, ciphertextPart]
+)
+
+smtp.send(mail) { error in
+    if let error = error { print(error) }
+}
+```
+
+On the wire this produces:
+
+```
+Content-Type: multipart/encrypted; boundary="..."; protocol="application/pgp-encrypted"
+
+--<boundary>
+Content-Type: application/pgp-encrypted
+
+Version: 1
+--<boundary>
+Content-Type: application/octet-stream
+Content-Disposition: inline; filename="encrypted.asc"
+
+-----BEGIN PGP MESSAGE-----
+...ASCII-armored ciphertext...
+-----END PGP MESSAGE-----
+--<boundary>--
+```
+
+**Notes:**
+
+- `Mail.text` is dropped when `pgp == true`. Any cleartext you want the recipient to see must be inside the encrypted payload.
+- If `attachments` is empty, `send` returns `SMTPError.missingPGPAttachment` — the library will not emit a `multipart/encrypted` envelope with no body parts.
+- The library does not validate the MIME types of the two parts; the caller is responsible for supplying a correct Version part and ciphertext part.
+
+#### Rendering without sending
+
+`Mail.render(to:)` writes the fully-formed MIME body (Content-Type onward, no SMTP envelope and no message headers) to any `OutputStream`. Useful when you want to compose or inspect the body offline — for example, when feeding the *pre-encryption* MIME structure (a `multipart/mixed` of text + attachments, with `pgp: false`) into your encryption step:
+
+```swift
+let stream = OutputStream(toMemory: ())
+stream.open()
+try mail.render(to: stream)
+let data = stream.property(forKey: .dataWrittenToMemoryStreamKey) as! Data
+let body = String(decoding: data, as: UTF8.self)
+```
+
 ## Acknowledgements
 
 Inspired by [Hedwig](https://github.com/onevcat/Hedwig) and [Perfect-SMTP](https://github.com/PerfectlySoft/Perfect-SMTP).

--- a/Sources/SwiftSMTP/Attachment.swift
+++ b/Sources/SwiftSMTP/Attachment.swift
@@ -150,46 +150,47 @@ extension Attachment {
         switch type {
 
         case .data(_, let mime, let name, let inline):
-            dictionary["CONTENT-TYPE"] = mime
+            dictionary["Content-Type"] = mime
             var attachmentDisposition = inline ? "inline" : "attachment"
             if let mimeName = name.mimeEncoded {
                 attachmentDisposition.append("; filename=\"\(mimeName)\"")
             }
-            dictionary["CONTENT-DISPOSITION"] = attachmentDisposition
-            dictionary["CONTENT-TRANSFER-ENCODING"] = "BASE64"
+            dictionary["Content-Disposition"] = attachmentDisposition
+            dictionary["Content-Transfer-Encoding"] = "BASE64"
 
         case .pgp(_, let mime, let name, let inline):
-            dictionary["CONTENT-TYPE"] = mime
+            dictionary["Content-Type"] = mime
             var attachmentDisposition = inline ? "inline" : "attachment"
             if name.count > 0 {
-                if let mimeName = name.mimeEncoded {
-                    attachmentDisposition.append("; filename=\"\(mimeName)\"")
-                }
-                dictionary["CONTENT-DISPOSITION"] = attachmentDisposition
+                //if let mimeName = name.mimeEncoded {
+                //    attachmentDisposition.append("; filename=\"\(mimeName)\"")
+                //}
+                attachmentDisposition.append("; filename=\"\(name)\"")
+                dictionary["Content-Disposition"] = attachmentDisposition
             }
 
         case .file(_, let mime, let name, let inline):
-            dictionary["CONTENT-TYPE"] = mime
+            dictionary["Content-Type"] = mime
             var attachmentDisposition = inline ? "inline" : "attachment"
             if let mimeName = name.mimeEncoded {
                 attachmentDisposition.append("; filename=\"\(mimeName)\"")
             }
-            dictionary["CONTENT-DISPOSITION"] = attachmentDisposition
-            dictionary["CONTENT-TRANSFER-ENCODING"] = "BASE64"
+            dictionary["Content-Disposition"] = attachmentDisposition
+            dictionary["Content-Transfer-Encoding"] = "BASE64"
 
         case .html(_, let characterSet, _):
-            dictionary["CONTENT-TYPE"] = "text/html; charset=\(characterSet)"
-            dictionary["CONTENT-DISPOSITION"] = "inline"
-            dictionary["CONTENT-TRANSFER-ENCODING"] = "BASE64"
+            dictionary["Content-Type"] = "text/html; charset=\(characterSet)"
+            dictionary["Content-Disposition"] = "inline"
+            dictionary["Content-Transfer-Encoding"] = "BASE64"
 
         }
 
 
         for (key, value) in additionalHeaders {
             let keyUppercased = key.uppercased()
-            if  keyUppercased != "CONTENT-TYPE" &&
-                keyUppercased != "CONTENT-DISPOSITION" &&
-                keyUppercased != "CONTENT-TRANSFER-ENCODING" {
+            if  keyUppercased != "Content-Type" &&
+                keyUppercased != "Content-Disposition" &&
+                keyUppercased != "Content-Transfer-Encoding" {
                 dictionary[keyUppercased] = value
             }
         }

--- a/Sources/SwiftSMTP/Attachment.swift
+++ b/Sources/SwiftSMTP/Attachment.swift
@@ -188,9 +188,9 @@ extension Attachment {
 
         for (key, value) in additionalHeaders {
             let keyUppercased = key.uppercased()
-            if  keyUppercased != "Content-Type" &&
-                keyUppercased != "Content-Disposition" &&
-                keyUppercased != "Content-Transfer-Encoding" {
+            if  keyUppercased != "CONTENT-TYPE" &&
+                keyUppercased != "CONTENT-DISPOSITION" &&
+                keyUppercased != "CONTENT-TRANSFER-ENCODING" {
                 dictionary[keyUppercased] = value
             }
         }

--- a/Sources/SwiftSMTP/Common.swift
+++ b/Sources/SwiftSMTP/Common.swift
@@ -21,7 +21,6 @@ enum Result<T, Error> {
     case failure(Error)
 }
 
-let cache = NSCache<AnyObject, AnyObject>()
 let CRLF = "\r\n"
 
 extension String {

--- a/Sources/SwiftSMTP/DataSender.swift
+++ b/Sources/SwiftSMTP/DataSender.swift
@@ -277,9 +277,9 @@ private extension String {
     // Embed plain text content of emails with the proper headers so that it is entered correctly.
     var embedded: String {
         var embeddedText = ""
-        embeddedText += "CONTENT-TYPE: text/plain; charset=utf-8\(CRLF)"
-        embeddedText += "CONTENT-TRANSFER-ENCODING: 7bit\(CRLF)"
-        embeddedText += "CONTENT-DISPOSITION: inline\(CRLF)"
+        embeddedText += "Content-Type: text/plain; charset=utf-8\(CRLF)"
+        embeddedText += "Content-Transfer-Encoding: 7bit\(CRLF)"
+        embeddedText += "Content-Disposition: inline\(CRLF)"
         embeddedText += "\(CRLF)\(self)\(CRLF)"
         return embeddedText
     }
@@ -290,27 +290,27 @@ private extension String {
     }
 
     static func makeMixedEncryptedHeader(boundary: String) -> String {
-        return "CONTENT-TYPE: multipart/encrypted; boundary=\"\(boundary)\"; protocol=\"application/pgp-encrypted\"\(CRLF)"
+        return "Content-Type: multipart/encrypted; boundary=\"\(boundary)\"; protocol=\"application/pgp-encrypted\"\(CRLF)"
     }
     
     static func makePGPContentHeaders() -> String {
-        return "CONTENT-TYPE: text/plain; charset=\"utf-8\"\(CRLF)CONTENT-TRANSFER-ENCODING: 7bit\(CRLF)CONTENT-DISPOSITION: inline\(CRLF)"
+        return "Content-Type: text/plain; charset=\"utf-8\"\(CRLF)Content-Transfer-Encoding: 7bit\(CRLF)Content-Disposition: inline\(CRLF)"
     }
 
     // Header for a mixed type email.
     static func makeMixedHeader(boundary: String) -> String {
-        return "CONTENT-TYPE: multipart/mixed; boundary=\"\(boundary)\"\(CRLF)"
+        return "Content-Type: multipart/mixed; boundary=\"\(boundary)\"\(CRLF)"
     }
 
     // Header for an alternative email.
     static func makeAlternativeHeader(boundary: String) -> String {
-        return "CONTENT-TYPE: multipart/alternative; boundary=\"\(boundary)\"\(CRLF)"
+        return "Content-Type: multipart/alternative; boundary=\"\(boundary)\"\(CRLF)"
     }
 
     // Header for an attachment that is related to another attachment. (Such as an image attachment that can be
     // referenced by a related HTML attachment)
     static func makeRelatedHeader(boundary: String) -> String {
-        return "CONTENT-TYPE: multipart/related; boundary=\"\(boundary)\"\(CRLF)"
+        return "Content-Type: multipart/related; boundary=\"\(boundary)\"\(CRLF)"
     }
 
     // Added to a boundary to indicate the beginning of the corresponding section.

--- a/Sources/SwiftSMTP/DataSender.swift
+++ b/Sources/SwiftSMTP/DataSender.swift
@@ -42,7 +42,12 @@ struct DataSender {
         if includeHeaders {
             try sendHeaders(mail.headersString)
         }
-        if mail.hasAttachment {
+        if mail.pgp {
+            // Route PGP first — even with no attachments — so the
+            // missingPGPAttachment guard fires instead of silently emitting a
+            // plaintext body.
+            try sendPGPMIME(mail)
+        } else if mail.hasAttachment {
             try sendMixed(mail)
         } else {
             try sendText(mail.text)
@@ -60,28 +65,15 @@ extension DataSender {
     func sendText(_ text: String) throws {
         try send(text.embedded)
     }
-    // Add custom/default headers to a `Mail`'s text and write it to the socket.
-    func sendPGP(_ text: String) throws {
-        try send(text);
-    }
 
-    // Send `mail`'s content that is more than just plain text
+    // Send `mail`'s content that is more than just plain text. Callers should
+    // route `mail.pgp == true` to `sendPGPMIME` directly — this path is for
+    // non-encrypted multipart/mixed only.
     func sendMixed(_ mail: Mail) throws {
         let boundary = String.makeBoundary()
-        
-        var mixedHeader: String
-        if mail.pgp {
-            mixedHeader = String.makeMixedEncryptedHeader(boundary: boundary)
-        } else {
-            mixedHeader = String.makeMixedHeader(boundary: boundary)
-        }
-
-        try send(mixedHeader)
-        if !mail.pgp || mail.text.count > 0 {
-            try send(boundary.startLine)
-        }
+        try send(String.makeMixedHeader(boundary: boundary))
+        try send(boundary.startLine)
         try sendAlternative(for: mail)
-
         try sendAttachments(mail.attachments, boundary: boundary)
     }
 
@@ -103,15 +95,7 @@ extension DataSender {
             return
         }
 
-        if mail.pgp {
-            if mail.text.count > 0 {
-                let pgpheader = String.makePGPContentHeaders()
-                try send(pgpheader)
-                try sendPGP(mail.text + CRLF)
-            }
-        } else {
-            try sendText(mail.text)
-        }
+        try sendText(mail.text)
     }
 
     // Sends the attachments of a `Mail`.
@@ -121,6 +105,20 @@ extension DataSender {
             try sendAttachment(attachment)
         }
         try send(boundary.endLine)
+    }
+
+    // Frame the caller's attachments as an RFC 3156 §4 `multipart/encrypted`
+    // body. The caller is responsible for supplying both required parts (the
+    // `application/pgp-encrypted` Version part and the ciphertext) as
+    // attachments in order; the library only frames them and refuses to emit
+    // `mail.text` so no plaintext leaks alongside the encrypted body.
+    func sendPGPMIME(_ mail: Mail) throws {
+        guard !mail.attachments.isEmpty else {
+            throw SMTPError.missingPGPAttachment
+        }
+        let boundary = String.makeBoundary()
+        try send(String.makeMixedEncryptedHeader(boundary: boundary))
+        try sendAttachments(mail.attachments, boundary: boundary)
     }
 
     // Send the `attachment`.
@@ -151,100 +149,30 @@ extension DataSender {
         }
     }
 
-    // Send a PGP attachment.
+    // Send a PGP attachment. The body is already ASCII-armored, so no encoding
+    // step is needed and there is nothing worth caching.
     func sendPGPAttachment(_ pgp: String) throws {
-        #if os(macOS)
-        if let encodedData = cache.object(forKey: pgp as AnyObject) as? Data {
-            return try send(encodedData)
-        }
-        #else
-        if let data = cache.object(forKey: NSString(string: pgp) as AnyObject) as? Data {
-            return try send(data)
-        }
-        #endif
-
         try send(pgp)
-
-        #if os(macOS)
-            cache.setObject(encodedData as AnyObject, forKey: data as AnyObject)
-        #else
-            cache.setObject(NSString(string: pgp) as AnyObject, forKey: NSString(string: pgp) as AnyObject)
-        #endif
     }
 
-    // Send a data attachment. Data must be base 64 encoded before sending.
-    // Checks if the base 64 encoded version has been cached first.
+    // Send a data attachment, base64-encoded.
     func sendData(_ data: Data) throws {
-        #if os(macOS)
-            if let encodedData = cache.object(forKey: data as AnyObject) as? Data {
-                return try send(encodedData)
-            }
-        #else
-        
-            if let encodedData = cache.object(forKey: NSData(data: data) as AnyObject) as? Data {
-                return try send(encodedData)
-            }
-        #endif
-
-        let encodedData = data.base64EncodedData(options: .lineLength76Characters)
-        try send(encodedData)
-
-        #if os(macOS)
-            cache.setObject(encodedData as AnyObject, forKey: data as AnyObject)
-        #else
-            cache.setObject(NSData(data: encodedData) as AnyObject, forKey: NSData(data: data) as AnyObject)
-        #endif
+        try send(data.base64EncodedData(options: .lineLength76Characters))
     }
 
-    // Sends a local file at the given path. File must be base 64 encoded before sending. Checks the cache first.
-    // Throws an error if file could not be found.
+    // Send a local file, base64-encoded.
     func sendFile(at path: String) throws {
-        #if os(macOS)
-            if let data = cache.object(forKey: path as AnyObject) as? Data {
-                return try send(data)
-            }
-        #else
-            if let data = cache.object(forKey: NSString(string: path) as AnyObject) as? Data {
-                return try send(data)
-            }
-        #endif
-
         guard let file = FileHandle(forReadingAtPath: path) else {
             throw SMTPError.fileNotFound(path: path)
         }
-
-        let data = file.readDataToEndOfFile().base64EncodedData(options: .lineLength76Characters)
-        try send(data)
-        file.closeFile()
-
-        #if os(macOS)
-            cache.setObject(data as AnyObject, forKey: path as AnyObject)
-        #else
-            cache.setObject(NSData(data: data) as AnyObject, forKey: NSString(string: path) as AnyObject)
-        #endif
+        defer { file.closeFile() }
+        try send(file.readDataToEndOfFile().base64EncodedData(options: .lineLength76Characters))
     }
 
-    // Send an HTML attachment. HTML must be base 64 encoded before sending.
-    // Checks if the base 64 encoded version is in cache first.
+    // Send an HTML attachment, base64-encoded.
     func sendHTML(_ html: String) throws {
-        #if os(macOS)
-            if let encodedHTML = cache.object(forKey: html as AnyObject) as? String {
-                return try send(encodedHTML)
-            }
-        #else
-            if let encodedHTML = cache.object(forKey: NSString(string: html) as AnyObject) as? String {
-                return try send(encodedHTML)
-            }
-        #endif
-
-        let encodedHTML = html.data(using: .utf8)?.base64EncodedData(options: .lineLength76Characters) ?? Data()
-        try send(encodedHTML)
-
-        #if os(macOS)
-            cache.setObject(encodedHTML as AnyObject, forKey: html as AnyObject)
-        #else
-            cache.setObject(NSData(data: encodedHTML) as AnyObject, forKey: NSString(string: html) as AnyObject)
-        #endif
+        let encoded = html.data(using: .utf8)?.base64EncodedData(options: .lineLength76Characters) ?? Data()
+        try send(encoded)
     }
 }
 
@@ -292,10 +220,6 @@ private extension String {
     static func makeMixedEncryptedHeader(boundary: String) -> String {
         return "Content-Type: multipart/encrypted; boundary=\"\(boundary)\"; protocol=\"application/pgp-encrypted\"\(CRLF)"
     }
-    
-    static func makePGPContentHeaders() -> String {
-        return "Content-Type: text/plain; charset=\"utf-8\"\(CRLF)Content-Transfer-Encoding: 7bit\(CRLF)Content-Disposition: inline\(CRLF)"
-    }
 
     // Header for a mixed type email.
     static func makeMixedHeader(boundary: String) -> String {
@@ -329,26 +253,23 @@ extension OutputStream {
     func write(_ data: Data) throws {
         var remaining = data[...]
         while !remaining.isEmpty {
-            let bytesWritten = remaining.withUnsafeBytes { buf in
-                // The force unwrap is safe because we know that `remaining` is
-                // not empty. The `assumingMemoryBound(to:)` is there just to
-                // make Swift’s type checker happy. This would be unnecessary if
-                // `write(_:maxLength:)` were (as it should be IMO) declared
-                // using `const void *` rather than `const uint8_t *`.
-                self.write(
+            let bytesWritten = remaining.withUnsafeBytes { buf -> Int in
+                // baseAddress is non-nil because `remaining` is non-empty.
+                // assumingMemoryBound is there because Foundation declares the
+                // pointer as `UnsafePointer<UInt8>` rather than `void *`.
+                return self.write(
                     buf.baseAddress!.assumingMemoryBound(to: UInt8.self),
                     maxLength: buf.count
                 )
             }
-            guard bytesWritten >= 0 else {
-                // … if -1, throw `streamError` …
-                // … if 0, well, that’s a complex question …
-                if let error = self.streamError {
-                    print(error.localizedDescription ?? "Unknown error")
-                }
-                fatalError()
+            if bytesWritten > 0 {
+                remaining = remaining.dropFirst(bytesWritten)
+            } else {
+                // 0 means no space without blocking; <0 means error. Either
+                // way we can't make progress — surface to the caller instead
+                // of spinning or aborting the process.
+                throw self.streamError ?? SMTPError.streamWriteFailed
             }
-            remaining = remaining.dropFirst(bytesWritten)
         }
     }
 }

--- a/Sources/SwiftSMTP/Mail.swift
+++ b/Sources/SwiftSMTP/Mail.swift
@@ -39,6 +39,9 @@ public struct Mail {
     /// Text of the `Mail`. Defaults to none.
     public let text: String
 
+    /// Is this PGP/MIME.?  Defaults to none.
+    public let pgp: Bool
+    
     /// Array of `Attachment`s for the `Mail`. If the `Mail` has multiple `Attachment`s that are alternatives to plain
     /// text, the last one will be used as the alternative (all the `Attachments` will still be sent). Defaults to none.
     public let attachments: [Attachment]
@@ -88,6 +91,7 @@ public struct Mail {
                 bcc: [User] = [],
                 subject: String = "",
                 text: String = "",
+                pgp: Bool = false,
                 attachments: [Attachment] = [],
                 additionalHeaders: [String: String] = [:]) {
         self.from = from
@@ -96,7 +100,7 @@ public struct Mail {
         self.bcc = bcc
         self.subject = subject
         self.text = text
-
+        self.pgp = pgp
         let (alternative, attachments) = Mail.getAlternative(attachments)
         self.alternative = alternative
         self.attachments = attachments
@@ -143,7 +147,7 @@ public struct Mail {
         return dictionary
     }
 
-    var headersString: String {
+    public var headersString: String {
         return headersDictionary.map { (key, value) in
             return "\(key): \(value)"
             }.joined(separator: CRLF)

--- a/Sources/SwiftSMTP/Mail.swift
+++ b/Sources/SwiftSMTP/Mail.swift
@@ -58,16 +58,15 @@ public struct Mail {
         return "<\(uuid).Swift-SMTP@\(hostname)>"
     }
 
-    /// Hostname from the email address.
+    /// Hostname from the email address. Falls back to `localhost` when the
+    /// sender address has no `@` — keeps `Mail.id` from trapping on
+    /// malformed input.
     public var hostname: String {
         let fullEmail = from.email
-#if swift(>=4.2)
-        let atIndex = fullEmail.firstIndex(of: "@")
-#else
-        let atIndex = fullEmail.index(of: "@")
-#endif
-        let hostStart = fullEmail.index(after: atIndex!)
-        return String(fullEmail[hostStart...])
+        guard let atIndex = fullEmail.firstIndex(of: "@") else {
+            return "localhost"
+        }
+        return String(fullEmail[fullEmail.index(after: atIndex)...])
     }
 
     /// Initializes a `Mail` object.
@@ -121,36 +120,37 @@ public struct Mail {
         return (nil, attachments)
     }
 
-    private var headersDictionary: [String: String] {
-        var dictionary = [String: String]()
-        dictionary["MESSAGE-ID"] = id
-        dictionary["DATE"] = Date().smtpFormatted
-        dictionary["FROM"] = from.mime
-        dictionary["TO"] = to.map { $0.mime }.joined(separator: ", ")
-
+    // Built in canonical RFC 5322 §3.6 order so output is deterministic across
+    // runs. Custom headers follow the well-known ones, sorted alphabetically;
+    // last-write-wins on case-insensitive duplicates.
+    private var orderedHeaders: [(String, String)] {
+        var headers: [(String, String)] = []
+        headers.append(("DATE", Date().smtpFormatted))
+        headers.append(("FROM", from.mime))
+        headers.append(("TO", to.map { $0.mime }.joined(separator: ", ")))
         if !cc.isEmpty {
-            dictionary["CC"] = cc.map { $0.mime }.joined(separator: ", ")
+            headers.append(("CC", cc.map { $0.mime }.joined(separator: ", ")))
         }
+        headers.append(("SUBJECT", subject.mimeEncoded ?? ""))
+        headers.append(("MESSAGE-ID", id))
+        headers.append(("MIME-VERSION", "1.0 (Swift-SMTP)"))
 
-        dictionary["SUBJECT"] = subject.mimeEncoded ?? ""
-        dictionary["MIME-VERSION"] = "1.0 (Swift-SMTP)"
-
+        let reserved: Set<String> = ["CONTENT-TYPE", "CONTENT-DISPOSITION", "CONTENT-TRANSFER-ENCODING"]
+        var custom: [String: String] = [:]
         for (key, value) in additionalHeaders {
-            let keyUppercased = key.uppercased()
-            if  keyUppercased != "CONTENT-TYPE" &&
-                keyUppercased != "CONTENT-DISPOSITION" &&
-                keyUppercased != "CONTENT-TRANSFER-ENCODING" {
-                dictionary[keyUppercased] = value
+            let upper = key.uppercased()
+            if !reserved.contains(upper) {
+                custom[upper] = value
             }
         }
-
-        return dictionary
+        for key in custom.keys.sorted() {
+            headers.append((key, custom[key]!))
+        }
+        return headers
     }
 
     public var headersString: String {
-        return headersDictionary.map { (key, value) in
-            return "\(key): \(value)"
-            }.joined(separator: CRLF)
+        return orderedHeaders.map { "\($0.0): \($0.1)" }.joined(separator: CRLF)
     }
 
     var hasAttachment: Bool {
@@ -188,8 +188,11 @@ extension Mail {
 }
 
 extension DateFormatter {
+    // RFC 5322 §3.3 requires English day/month names regardless of the host
+    // system locale, so pin to POSIX.
     static let smtpDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "EEE, d MMM yyyy HH:mm:ss ZZZ"
         return formatter
     }()
@@ -198,5 +201,14 @@ extension DateFormatter {
 extension Date {
     var smtpFormatted: String {
         return DateFormatter.smtpDateFormatter.string(from: self)
+    }
+}
+
+public extension Mail {
+    /// Render this `Mail`'s MIME body (Content-Type onward, no message headers
+    /// and no SMTP envelope) to the given `OutputStream`. Useful for offline
+    /// composition or for piping through a non-SMTP transport.
+    func render(to stream: OutputStream) throws {
+        try DataSender(stream: stream).send(self, includeHeaders: false)
     }
 }

--- a/Sources/SwiftSMTP/MailSender.swift
+++ b/Sources/SwiftSMTP/MailSender.swift
@@ -27,48 +27,30 @@ public typealias Progress = ((Mail, Error?) -> Void)?
 ///  sent `Mail`s. [(`Mail`, `Error`)] is an array of failed `Mail`s and their corresponding `Error`s.
 public typealias Completion = (([Mail], [(Mail, Error)]) -> Void)?
 
-public class MailSender {
-    private var socket: SMTPSocket?
-    private var stream: OutputStream?
+class MailSender {
+    private let socket: SMTPSocket
     private var mailsToSend: [Mail]
     private var progress: Progress
     private var completion: Completion
     private var sent = [Mail]()
     private var failed = [(Mail, Error)]()
-    private var dataSender: DataSender
+    private let dataSender: DataSender
 
     init(socket: SMTPSocket,
          mailsToSend: [Mail],
          progress: Progress,
          completion: Completion) {
         self.socket = socket
-        self.stream = nil
         self.mailsToSend = mailsToSend
         self.progress = progress
         self.completion = completion
         dataSender = DataSender(socket: socket)
     }
 
-    public init(stream: OutputStream,
-         mailsToSend: [Mail],
-         progress: Progress,
-         completion: Completion) {
-        self.socket = nil
-        self.mailsToSend = mailsToSend
-        self.progress = progress
-        self.completion = completion
-        self.stream = stream;
-        dataSender = DataSender(stream: stream)
-    }
-    
     func send() {
         DispatchQueue.global().async {
             self.sendNext()
         }
-    }
-    
-    public func render(_ mail: Mail) throws {
-        try dataSender.send(mail, includeHeaders: false)
     }
 }
 
@@ -99,15 +81,12 @@ private extension MailSender {
         }
     }
 
-    public func quit() throws {
-        if (socket != nil) {
-            try socket?.send(.quit)
-            socket?.close()
-        }
+    func quit() throws {
+        try socket.send(.quit)
+        socket.close()
     }
 
-    
-    public func send(_ mail: Mail) throws {
+    func send(_ mail: Mail) throws {
         let recipientEmails = try getRecipientEmails(from: mail)
         try validateEmails(recipientEmails)
         try sendMail(mail.from.email)
@@ -136,21 +115,21 @@ private extension MailSender {
     }
 
     func sendMail(_ from: String) throws {
-        try socket?.send(.mail(from))
+        try socket.send(.mail(from))
     }
 
     func sendTo(_ emails: [String]) throws {
         for email in emails {
-            try socket?.send(.rcpt(email))
+            try socket.send(.rcpt(email))
         }
     }
 
     func data() throws {
-        try socket?.send(.data)
+        try socket.send(.data)
     }
 
     func dataEnd() throws {
-        try socket?.send(.dataEnd)
+        try socket.send(.dataEnd)
     }
 }
 

--- a/Sources/SwiftSMTP/SMTP.swift
+++ b/Sources/SwiftSMTP/SMTP.swift
@@ -41,7 +41,7 @@ public struct SMTP {
 
         /// Expect a STARTTLS command from the server and require the connection is upgraded to TLS. Will throw if the server does not issue a STARTTLS command.
         case requireSTARTTLS
-    }
+    };
 
     /// Initializes an `SMTP` instance.
     ///
@@ -93,19 +93,37 @@ public struct SMTP {
         self.timeout = timeout
     }
 
+    /// Verify Auth Credentials.
+    ///
+    /// - Parameters:
+    ///     - completion: Callback when sending finishes. `Error` is nil on success. (optional)
+
     /// Send an email.
     ///
     /// - Parameters:
     ///     - mail: `Mail` object to send.
     ///     - completion: Callback when sending finishes. `Error` is nil on success. (optional)
-    public func send(_ mail: Mail, completion: ((Error?) -> Void)? = nil) {
-        send([mail], completion:  { (_, failed) in
-            if let error = failed.first?.1 {
-                completion?(error)
-            } else {
-                completion?(nil)
-            }
-        })
+    public func verifyAuth(completion:((_ res: Bool, _ error: Error?) -> Void)) {
+        var res: Bool = false;
+        do {
+            let socket = try SMTPSocket(
+                hostname: hostname,
+                email: email,
+                password: password,
+                port: port,
+                tlsMode: tlsMode,
+                tlsConfiguration: tlsConfiguration,
+                authMethods: authMethods,
+                domainName: domainName,
+                timeout: timeout
+            )
+            res = true;
+        } catch {
+            NSLog("Error: \(error)")
+            completion(false, error);
+            return
+        }
+        completion(res, nil);
     }
 
     /// Send multiple emails.

--- a/Sources/SwiftSMTP/SMTP.swift
+++ b/Sources/SwiftSMTP/SMTP.swift
@@ -103,8 +103,7 @@ public struct SMTP {
     /// - Parameters:
     ///     - mail: `Mail` object to send.
     ///     - completion: Callback when sending finishes. `Error` is nil on success. (optional)
-    public func verifyAuth(completion:((_ res: Bool, _ error: Error?) -> Void)) {
-        var res: Bool = false;
+    public func verifyAuth(completion: ((_ res: Bool, _ error: Error?) -> Void)) {
         do {
             let socket = try SMTPSocket(
                 hostname: hostname,
@@ -117,13 +116,12 @@ public struct SMTP {
                 domainName: domainName,
                 timeout: timeout
             )
-            res = true;
+            _ = try? socket.send(.quit)
+            socket.close()
+            completion(true, nil)
         } catch {
-            NSLog("Error: \(error)")
-            completion(false, error);
-            return
+            completion(false, error)
         }
-        completion(res, nil);
     }
 
     /// Send multiple emails.
@@ -172,5 +170,16 @@ public struct SMTP {
         } catch {
             completion?([], mails.map { ($0, error) })
         }
+    }
+
+    /// Send a single email.
+    ///
+    /// - Parameters:
+    ///     - mail: `Mail` to send.
+    ///     - completion: Callback when sending finishes. `Error` is nil on success. (optional)
+    public func send(_ mail: Mail, completion: ((Error?) -> Void)? = nil) {
+        send([mail], completion: { _, failed in
+            completion?(failed.first?.1)
+        })
     }
 }

--- a/Sources/SwiftSMTP/SMTPError.swift
+++ b/Sources/SwiftSMTP/SMTPError.swift
@@ -53,6 +53,15 @@ public enum SMTPError: Error, CustomStringConvertible {
 
     /// STARTTLS was required but the server did not request it.
     case requiredSTARTTLS
+
+    /// `Mail.pgp` was set but no PGP attachment was supplied for the encrypted body part.
+    case missingPGPAttachment
+
+    /// Writing to an `OutputStream` failed without surfacing a `streamError`.
+    case streamWriteFailed
+
+    /// Server closed the connection before sending a complete SMTP response.
+    case incompleteResponse(response: String)
     
     /// Description of the `SMTPError`.
     public var description: String {
@@ -67,6 +76,9 @@ public enum SMTPError: Error, CustomStringConvertible {
         case .convertDataUTF8Fail(let buf): return "Error converting Data read from socket to a String: \(buf)."
         case .invalidEmail(let email): return "Invalid email provided for User: \(email)."
         case .requiredSTARTTLS: return "STARTTLS was required but the server did not issue a STARTTLS command."
+        case .missingPGPAttachment: return "Mail.pgp was set but no PGP attachment was supplied for the encrypted body part."
+        case .streamWriteFailed: return "Writing to OutputStream failed."
+        case .incompleteResponse(let r): return "Server closed connection before sending a complete response. Partial: \(r)"
         }
     }
 

--- a/Sources/SwiftSMTP/SMTPSocket.swift
+++ b/Sources/SwiftSMTP/SMTPSocket.swift
@@ -75,13 +75,36 @@ struct SMTPSocket {
 
 private extension SMTPSocket {
     func readFromSocket() throws -> String {
+        // An SMTP reply can span multiple TCP segments. Keep reading until the
+        // final line of a (possibly multi-line) reply arrives — that line uses
+        // a space after the response code, while continuation lines use a dash
+        // (RFC 5321 §4.2.1).
         var buf = Data()
-        _ = try socket.read(into: &buf)
-        guard let responses = String(data: buf, encoding: .utf8) else {
-            throw SMTPError.convertDataUTF8Fail(data: buf)
+        while true {
+            let bytesRead = try socket.read(into: &buf)
+            guard let responses = String(data: buf, encoding: .utf8) else {
+                throw SMTPError.convertDataUTF8Fail(data: buf)
+            }
+            if SMTPSocket.responseIsComplete(responses) {
+                Log.debug(responses)
+                return responses
+            }
+            if bytesRead == 0 {
+                throw SMTPError.incompleteResponse(response: responses)
+            }
         }
-        Log.debug(responses)
-        return responses
+    }
+
+    static func responseIsComplete(_ text: String) -> Bool {
+        guard text.hasSuffix(CRLF) else { return false }
+        let trimmed = text.dropLast(2)
+        guard let lastLine = trimmed.components(separatedBy: CRLF).last,
+              lastLine.count >= 4 else {
+            return false
+        }
+        let codeChars = lastLine.prefix(3)
+        let separator = lastLine[lastLine.index(lastLine.startIndex, offsetBy: 3)]
+        return codeChars.allSatisfy { $0.isNumber } && separator == " "
     }
 
     @discardableResult
@@ -148,12 +171,14 @@ private extension SMTPSocket {
     }
 
     func getAuthMethod(authMethods: [String: AuthMethod], serverOptions: [Response], hostname: String) throws -> AuthMethod {
+        // SASL mechanism names are case-insensitive (RFC 4954 §4); some
+        // servers advertise them lowercase.
         for option in serverOptions {
             let components = option.message.components(separatedBy: " ")
-            if components.first == "AUTH" {
+            if components.first?.uppercased() == "AUTH" {
                 let _authMethods = components.dropFirst()
                 for authMethod in _authMethods {
-                    if let matchingAuthMethod = authMethods[authMethod] {
+                    if let matchingAuthMethod = authMethods[authMethod.uppercased()] {
                         return matchingAuthMethod
                     }
                 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -50,5 +50,6 @@ XCTMain([
     testCase(TestDataSender.allTests.shuffled()),
     testCase(TestMailSender.allTests.shuffled()),
     testCase(TestMiscellaneous.allTests.shuffled()),
+    testCase(TestPGPMIME.allTests.shuffled()),
     testCase(TestSMTPSocket.allTests.shuffled()),
     testCase(TestTLSMode.allTests.shuffled())].shuffled())

--- a/Tests/SwiftSMTPTests/TestPGPMIME.swift
+++ b/Tests/SwiftSMTPTests/TestPGPMIME.swift
@@ -1,0 +1,194 @@
+/**
+ * Copyright IBM Corporation 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import XCTest
+@testable import SwiftSMTP
+
+// Verifies the MIME structure produced by `Mail.render(to:)` when `Mail.pgp`
+// is set, against RFC 3156 §4 (security multiparts using PGP). These tests
+// render to an in-memory `OutputStream` and never touch the network, so they
+// don't require the live SMTP server the rest of the suite expects.
+class TestPGPMIME: XCTestCase {
+    static var allTests = [
+        ("testTopLevelHeaderIsMultipartEncrypted", testTopLevelHeaderIsMultipartEncrypted),
+        ("testFirstPartIsApplicationPGPEncryptedVersion", testFirstPartIsApplicationPGPEncryptedVersion),
+        ("testSecondPartContainsCiphertextAttachment", testSecondPartContainsCiphertextAttachment),
+        ("testBodyHasExactlyTwoParts", testBodyHasExactlyTwoParts),
+        ("testPlaintextIsDroppedWhenPGPSet", testPlaintextIsDroppedWhenPGPSet),
+        ("testMissingPGPAttachmentThrows", testMissingPGPAttachmentThrows),
+        ("testPGPAttachmentFilenamePreserved", testPGPAttachmentFilenamePreserved),
+    ]
+
+    // Realistic-looking ASCII armor. The content is never decrypted — these
+    // tests only verify MIME framing.
+    private let armoredCiphertext = """
+        -----BEGIN PGP MESSAGE-----
+        Version: GnuPG v2
+
+        hQEMA1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz
+        0123456789+/SGVsbG8gV29ybGQgdGhpcyBpcyBub3QgYWN0dWFsbHkgY2lwaGVydGV4dA==
+        =ABCD
+        -----END PGP MESSAGE-----
+        """
+
+    private let sender = Mail.User(name: "Alice", email: "alice@example.com")
+    private let recipient = Mail.User(name: "Bob", email: "bob@example.com")
+
+    private func makeVersionPart() -> Attachment {
+        // RFC 3156 §4 first body part: application/pgp-encrypted; "Version: 1".
+        return Attachment(pgp: "Version: 1", mime: "application/pgp-encrypted", name: "")
+    }
+
+    private func makeCiphertextPart(name: String = "encrypted.asc") -> Attachment {
+        return Attachment(pgp: armoredCiphertext, mime: "application/octet-stream", name: name)
+    }
+
+    private func makePGPMail(text: String = "", attachments: [Attachment]? = nil) -> Mail {
+        return Mail(
+            from: sender,
+            to: [recipient],
+            subject: "Encrypted message",
+            text: text,
+            pgp: true,
+            attachments: attachments ?? [makeVersionPart(), makeCiphertextPart()]
+        )
+    }
+
+    private func render(_ mail: Mail) throws -> String {
+        let stream = OutputStream(toMemory: ())
+        stream.open()
+        defer { stream.close() }
+        try mail.render(to: stream)
+        let data = stream.property(forKey: .dataWrittenToMemoryStreamKey) as? Data ?? Data()
+        guard let rendered = String(data: data, encoding: .utf8) else {
+            XCTFail("Rendered body was not valid UTF-8")
+            return ""
+        }
+        return rendered
+    }
+
+    private func extractBoundary(from rendered: String) -> String? {
+        let pattern = #"multipart/encrypted;\s*boundary="([^"]+)""#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let range = NSRange(rendered.startIndex..<rendered.endIndex, in: rendered)
+        guard let match = regex.firstMatch(in: rendered, range: range),
+              match.numberOfRanges >= 2,
+              let captureRange = Range(match.range(at: 1), in: rendered) else {
+            return nil
+        }
+        return String(rendered[captureRange])
+    }
+
+    func testTopLevelHeaderIsMultipartEncrypted() throws {
+        let rendered = try render(makePGPMail())
+        XCTAssert(rendered.contains("Content-Type: multipart/encrypted"),
+                  "Top-level Content-Type must be multipart/encrypted (RFC 3156 §4)")
+        XCTAssert(rendered.contains(#"protocol="application/pgp-encrypted""#),
+                  "multipart/encrypted must carry the protocol=application/pgp-encrypted parameter")
+        XCTAssertNotNil(extractBoundary(from: rendered),
+                        "multipart/encrypted Content-Type must declare a quoted boundary")
+    }
+
+    func testFirstPartIsApplicationPGPEncryptedVersion() throws {
+        let rendered = try render(makePGPMail())
+        guard let boundary = extractBoundary(from: rendered) else {
+            XCTFail("No boundary; cannot locate first part")
+            return
+        }
+        let parts = rendered.components(separatedBy: "--\(boundary)")
+        // [0] preamble, [1] first part, [2] second part, [3] (trailing — contains the "--" close marker)
+        guard parts.count >= 3 else {
+            XCTFail("Expected at least 2 body parts, found \(parts.count - 1)")
+            return
+        }
+        let firstPart = parts[1]
+        XCTAssert(firstPart.contains("Content-Type: application/pgp-encrypted"),
+                  "First part must declare Content-Type: application/pgp-encrypted")
+        XCTAssert(firstPart.contains("Version: 1"),
+                  "First part body must be \"Version: 1\" per RFC 3156 §4")
+    }
+
+    func testSecondPartContainsCiphertextAttachment() throws {
+        let rendered = try render(makePGPMail())
+        guard let boundary = extractBoundary(from: rendered) else {
+            XCTFail("No boundary; cannot locate second part")
+            return
+        }
+        let parts = rendered.components(separatedBy: "--\(boundary)")
+        guard parts.count >= 3 else {
+            XCTFail("Expected at least 2 body parts, found \(parts.count - 1)")
+            return
+        }
+        let secondPart = parts[2]
+        XCTAssert(secondPart.contains("Content-Type: application/octet-stream"),
+                  "Second part should carry the attachment's declared MIME type")
+        XCTAssert(secondPart.contains("-----BEGIN PGP MESSAGE-----"),
+                  "Second part body must contain the ASCII-armored ciphertext")
+        XCTAssert(secondPart.contains("-----END PGP MESSAGE-----"),
+                  "Second part body must contain the ASCII-armor terminator")
+    }
+
+    func testBodyHasExactlyTwoParts() throws {
+        let rendered = try render(makePGPMail())
+        guard let boundary = extractBoundary(from: rendered) else {
+            XCTFail("No boundary; cannot count parts")
+            return
+        }
+        // Count delimiter occurrences. A correct two-part body has the
+        // boundary appearing 3 times in raw form (2 part openers + 1 closer);
+        // the closer is "--BOUNDARY--", so splitting on the bare "--BOUNDARY"
+        // delimiter yields preamble + 2 parts + the "--" tail.
+        let segments = rendered.components(separatedBy: "--\(boundary)")
+        XCTAssertEqual(segments.count, 4,
+                       "RFC 3156 multipart/encrypted must contain exactly two body parts (Version + ciphertext), got \(segments.count - 2)")
+        XCTAssert(rendered.contains("--\(boundary)--"),
+                  "Multipart body must terminate with the closing boundary delimiter")
+    }
+
+    func testPlaintextIsDroppedWhenPGPSet() throws {
+        let secret = "this plaintext must NOT leak alongside the encrypted body"
+        let rendered = try render(makePGPMail(text: secret))
+        XCTAssertFalse(rendered.contains(secret),
+                       "mail.text must not appear inside a multipart/encrypted envelope — it would defeat the encryption")
+    }
+
+    func testMissingPGPAttachmentThrows() {
+        let mail = Mail(
+            from: sender,
+            to: [recipient],
+            subject: "Encrypted",
+            text: "",
+            pgp: true,
+            attachments: []
+        )
+        let stream = OutputStream(toMemory: ())
+        stream.open()
+        defer { stream.close() }
+        XCTAssertThrowsError(try mail.render(to: stream)) { error in
+            guard let smtpError = error as? SMTPError, case .missingPGPAttachment = smtpError else {
+                XCTFail("Expected SMTPError.missingPGPAttachment, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testPGPAttachmentFilenamePreserved() throws {
+        let ciphertext = makeCiphertextPart(name: "msg.asc")
+        let rendered = try render(makePGPMail(attachments: [makeVersionPart(), ciphertext]))
+        XCTAssert(rendered.contains(#"filename="msg.asc""#),
+                  "Attachment's filename must surface in Content-Disposition")
+    }
+}


### PR DESCRIPTION
## Description

This PR adds two new capabilities to Swift-SMTP and includes related robustness fixes:

- **PGP/MIME support.** Mail can now be sent as a PGP/MIME (`multipart/encrypted`) message. A new `pgp: Bool` flag on `Mail` and a `pgp:` initializer on `Attachment` drive the encrypted formatting path in `DataSender.sendMixed`, producing a properly structured `multipart/encrypted; protocol="application/pgp-encrypted"` body.
- **In-memory message rendering.** `MailSender` and `DataSender` gained stream-based initializers (`init(stream:…)` / `render(_:)`) that write a fully-formed RFC822/MIME message into an `OutputStream` in memory, without ever opening a socket or issuing SMTP commands. This makes it possible to generate and inspect message output for testing or for handing off to another transport.
- **Header casing fix.** MIME/SMTP headers are no longer emitted in all-caps.
- **Robustness improvements** from code review around the socket/stream dichotomy.
- **Documentation.** The README now describes PGP/MIME usage.
- Merged the latest upstream commit (#140), which switches `DataSender` wire-logging from `print` to `LoggerAPI` (`Log.debug`); the conflict was resolved so both the socket and the new in-memory stream paths log via `Log.debug`.

## Motivation and Context

Users needed (1) a way to send end-to-end encrypted email via PGP/MIME, and (2) a way to render a complete MIME message in memory rather than only being able to transmit it over a live SMTP connection. The latter also makes the formatting logic far easier to test in isolation. The header-casing change brings emitted headers in line with conventional casing, and the LoggerAPI merge gives consumers control over stdout output instead of unconditional `print`s.

## How Has This Been Tested?

- `swift build` succeeds cleanly after the merge resolution.
- `swift test` exercises the XCTest suite (note: the suite talks to a real SMTP server, `mail.kitura.dev`, using the `EMAIL`/`PASSWORD` environment variables and requires network reachability).
- The in-memory rendering path was validated by rendering messages to an `OutputStream` and inspecting the resulting RFC822/MIME output.

Testing environment: macOS (Darwin), Swift 5.2+, Swift Package Manager.

## Checklist:
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
